### PR TITLE
Add missing _root_ to controllers.AssetsComponents

### DIFF
--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -115,7 +115,7 @@ package routers {
   class MyComponents(context: Context)
       extends BuiltInComponentsFromContext(context)
       with HttpFiltersComponents
-      with controllers.AssetsComponents {
+      with _root_.controllers.AssetsComponents {
     lazy val barRoutes             = new bar.Routes(httpErrorHandler)
     lazy val applicationController = new controllers.Application(controllerComponents)
 


### PR DESCRIPTION
This fixes the [documentation](https://www.playframework.com/documentation/2.8.x/ScalaCompileTimeDependencyInjection#Providing-a-router) (see: To use this router in an actual application) to reflect the working code found in the compile time di [sample project](https://github.com/playframework/play-samples/blob/2.8.x/play-scala-compile-di-example/app/MyApplicationLoader.scala).

Without `_root_` in the documentation the following error occurs:

> type AssetsComponents is not a member of package play.api.controllers

`_root_.controllers.AssetsComponents` is the correct import path.


*[x] Signed the CLA*